### PR TITLE
Fix problem disabled of OPFS at e2e

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ test-results
 
 # mac
 .DS_Store
+
+# coi-serviceworker
+# These files are included in the .gitignore because they are automatically generated during the build process.
+# Run npm run build:e2e to generate the necessary files and place them in the correct location.
+e2e/coi-serviceworker.js

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ All tests are tested only through Playwright.
 * Google Chrome
 * Microsoft Edge
 * Firefox
-* Safari
+* ~~Safari~~ (https://github.com/shinshin86/neverchange/issues/6)
 
 ### Requirements
 

--- a/e2e/index.html
+++ b/e2e/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title>NeverChangeDB Test</title>
+  <script src="/coi-serviceworker.js"></script>
 </head>
 <body>
   <h1>NeverChangeDB Test Page</h1>

--- a/e2e/neverchange.test.ts
+++ b/e2e/neverchange.test.ts
@@ -102,8 +102,7 @@ test.describe("NeverChangeDB", () => {
     expect(closed).toBe(true);
   });
 
-  // if OPFS is disabled, this test will fail
-  test.skip("should persist data between connections", async ({ page }) => {
+  test("should persist data between connections", async ({ page }) => {
     await page.evaluate(async () => {
       const db1 = new (window as any).NeverChangeDB("persist-test-db");
       await db1.init();

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@biomejs/biome": "1.8.3",
         "@playwright/test": "^1.46.1",
         "@types/node": "^22.5.2",
+        "coi-serviceworker": "^0.1.7",
         "playwright": "^1.46.1",
         "typescript": "^5.5.3",
         "vite": "^5.4.2"
@@ -840,6 +841,13 @@
       "dependencies": {
         "undici-types": "~6.19.2"
       }
+    },
+    "node_modules/coi-serviceworker": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/coi-serviceworker/-/coi-serviceworker-0.1.7.tgz",
+      "integrity": "sha512-bjSUqEngCPOkErY2vbyWsaIGCNRODYzlNycaREVw5s12/C8SM+RnRUUeX6pZbTtov6C52ZLY/+tvHK+BDxuUuA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,10 @@
   },
   "scripts": {
     "build": "vite build && tsc",
-    "dev:e2e": "vite --mode e2e",
-    "e2e": "playwright test",
+    "e2e": "npm run build:e2e && playwright test",
+    "setupcoi:e2e": "cp node_modules/coi-serviceworker/coi-serviceworker.js e2e",
+    "build:e2e": "vite build && tsc && npm run setupcoi:e2e",
+    "dev:e2e": "npm run build:e2e && vite --mode e2e",
     "fmt": "biome format --write src e2e ",
     "prepublishOnly": "npm run build"
   },
@@ -53,6 +55,7 @@
     "@biomejs/biome": "1.8.3",
     "@playwright/test": "^1.46.1",
     "@types/node": "^22.5.2",
+    "coi-serviceworker": "^0.1.7",
     "playwright": "^1.46.1",
     "typescript": "^5.5.3",
     "vite": "^5.4.2"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,13 +40,6 @@ export default defineConfig({
         headless: true,
       },
     },
-    {
-      name: 'webkit',
-      use: {
-        ...devices['Desktop Safari'],
-        headless: true,
-      },
-    },
   ],
   webServer: {
     command: 'npm run dev:e2e',


### PR DESCRIPTION
Using coi-serviceworker solved the problem of disabled of OPFS.

And... neverchange will not support Safari until a solution is found.
https://github.com/shinshin86/neverchange/issues/6