### PR TITLE
Add headers for dev:e2e local server

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ NeverChange is a database solution for web applications using SQLite WASM and OP
 
 - [Installation](#installation)
 - [Supported Browsers](#supported-browsers)
+- [You want to host on GitHub Pages and Netlify](#you-want-to-host-on-github-pages-and-netlify)
 - [Requirements](#requirements)
 - [Usage](#usage)
   - [Basic](#basic)
@@ -45,8 +46,8 @@ All tests are tested only through Playwright.
 * Firefox
 * ~~Safari~~ (https://github.com/shinshin86/neverchange/issues/6)
 
-## You want to host on GitHub Pages
-If you want to host on GitHub Pages, you will need [coi-serviceworker.js](https://github.com/gzuidhof/coi-serviceworker).  
+## You want to host on GitHub Pages and Netlify
+If you want to host on GitHub Pages and Netlify, you will need [coi-serviceworker.js](https://github.com/gzuidhof/coi-serviceworker).  
 Also, Safari does not function properly in this case. Refer to the following issue for more details.  
 https://github.com/shinshin86/neverchange/issues/6
 
@@ -56,19 +57,18 @@ example:
 <!DOCTYPE html>
 <html>
 <head>
-  <title>NeverChangeDB Test</title>
-  <!-- If you want to host on GitHub Pages, you will need coi-serviceworker.js -->
+  <title>NeverChange Example</title>
+  <!-- If you want to host on GitHub Pages and Netlify, you will need coi-serviceworker.js -->
   <script src="/coi-serviceworker.js"></script>
 </head>
 <body>
-  <h1>NeverChangeDB Test Page</h1>
-  <script type="module">
-    import { NeverChangeDB } from '../src/index.ts';
-    window.NeverChangeDB = NeverChangeDB;
-  </script>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx">
 </body>
 </html>
 ```
+
+A more detailed deployment guide can be found in the [Deployment Documentation](docs/deployment.md).
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,31 @@ All tests are tested only through Playwright.
 * Firefox
 * ~~Safari~~ (https://github.com/shinshin86/neverchange/issues/6)
 
+## You want to host on GitHub Pages
+If you want to host on GitHub Pages, you will need [coi-serviceworker.js](https://github.com/gzuidhof/coi-serviceworker).  
+Also, Safari does not function properly in this case. Refer to the following issue for more details.  
+https://github.com/shinshin86/neverchange/issues/6
+
+example:
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <title>NeverChangeDB Test</title>
+  <!-- If you want to host on GitHub Pages, you will need coi-serviceworker.js -->
+  <script src="/coi-serviceworker.js"></script>
+</head>
+<body>
+  <h1>NeverChangeDB Test Page</h1>
+  <script type="module">
+    import { NeverChangeDB } from '../src/index.ts';
+    window.NeverChangeDB = NeverChangeDB;
+  </script>
+</body>
+</html>
+```
+
 ## Requirements
 
 - Node.js (version 20 or higher recommended)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,113 @@
+# Deployment Guide (GitHub Pages and Netlify)
+
+This document provides detailed instructions for deploying NeverChange on GitHub Pages and Netlify. Follow the steps below to set up your deployment.
+
+## Table of Contents
+- [Prerequisites](#prerequisites)
+- [When using Vite on GitHub Pages](#when-using-vite-on-github-pages)
+- [When using Vite on Netlify](#when-using-vite-on-netlify)
+
+## Prerequisites
+
+Both GitHub Pages and Netlify require the use of [coi-serviceworker.js](https://github.com/gzuidhof/coi-serviceworker).
+
+When using GitHub Pages, OPFS is unavailable because you cannot set the `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` headers.
+
+The `coi-serviceworker` helps work around this limitation.
+
+However, this service worker mechanism does not function correctly in Safari, making Safari incompatible with these environments.
+
+You can load and use it in HTML as shown below:
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <title>NeverChange Example</title>
+  <!-- coi-serviceworker.js is required for GitHub Pages or Netlify hosting -->
+  <script src="/coi-serviceworker.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+</html>
+```
+
+## When using Vite on GitHub Pages
+If you are building a site with Vite + React on GitHub Pages, use the following configuration to ensure compatibility with OPFS.
+
+```typescript
+import { defineConfig, Plugin } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// This htmlPlugin configuration is tailored for GitHub Pages. It automatically injects the coi-serviceworker.js script into the HTML <head> during build time.
+// It's useful for ensuring that the necessary service worker is included without manually editing the HTML file.
+// This helps avoid cross-origin issues and enables the COOP and COEP headers required for OPFS.
+const htmlPlugin = (): Plugin => {
+  return {
+    name: 'html-transform',
+    transformIndexHtml(html: string) {
+      return html.replace(
+        '</title>',
+        `</title>\n    <script src="/your-project-name/coi-serviceworker.js"></script>`,
+      );
+    },
+  };
+};
+
+export default defineConfig({
+  base: '/your-project-name/',
+  plugins: [react(), htmlPlugin()],
+  server: {
+    headers: {
+      'Cross-Origin-Opener-Policy': 'same-origin',
+      'Cross-Origin-Embedder-Policy': 'require-corp',
+    },
+  },
+  optimizeDeps: {
+    exclude: ['@sqlite.org/sqlite-wasm'],
+  },
+});
+```
+
+
+## When using Vite on Netlify
+If you are building a site with Vite + React on Netlify, use the following configuration to ensure compatibility with OPFS.
+
+This setup is similar to the GitHub Pages method, but on Netlify, you don’t need to specify the `base: '/your-project-name/'` option, as Netlify’s URLs are typically in the format `http(s)://<project-name>.netlify.app/`, and a base path isn’t required. 
+
+Note that `htmlPlugin` also differs slightly for the same reason, so please take note of this difference.
+
+```typescript
+import { defineConfig, Plugin } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// This htmlPlugin configuration is tailored for Netlify. It automatically injects the coi-serviceworker.js script into the HTML <head> during build time.
+// It's useful for ensuring that the necessary service worker is included without manually editing the HTML file.
+// This helps avoid cross-origin issues and enables the COOP and COEP headers required for OPFS.
+const htmlPlugin = (): Plugin => {
+  return {
+    name: 'html-transform',
+    transformIndexHtml(html: string) {
+      return html.replace(
+        '</title>',
+        `</title>\n    <script src="/coi-serviceworker.js"></script>`,
+      );
+    },
+  };
+};
+
+export default defineConfig({
+  plugins: [react(), htmlPlugin()],
+  server: {
+    headers: {
+      'Cross-Origin-Opener-Policy': 'same-origin',
+      'Cross-Origin-Embedder-Policy': 'require-corp',
+    },
+  },
+  optimizeDeps: {
+    exclude: ['@sqlite.org/sqlite-wasm'],
+  },
+});
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@biomejs/biome": "1.8.3",
         "@playwright/test": "^1.46.1",
         "@types/node": "^22.5.2",
-        "coi-serviceworker": "^0.1.7",
         "playwright": "^1.46.1",
         "typescript": "^5.5.3",
         "vite": "^5.4.2"
@@ -841,13 +840,6 @@
       "dependencies": {
         "undici-types": "~6.19.2"
       }
-    },
-    "node_modules/coi-serviceworker": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/coi-serviceworker/-/coi-serviceworker-0.1.7.tgz",
-      "integrity": "sha512-bjSUqEngCPOkErY2vbyWsaIGCNRODYzlNycaREVw5s12/C8SM+RnRUUeX6pZbTtov6C52ZLY/+tvHK+BDxuUuA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",

--- a/package.json
+++ b/package.json
@@ -23,10 +23,8 @@
   },
   "scripts": {
     "build": "vite build && tsc",
-    "e2e": "npm run build:e2e && playwright test",
-    "setupcoi:e2e": "cp node_modules/coi-serviceworker/coi-serviceworker.js e2e",
-    "build:e2e": "vite build && tsc && npm run setupcoi:e2e",
-    "dev:e2e": "npm run build:e2e && vite --mode e2e",
+    "e2e": "npm run build && playwright test",
+    "dev:e2e": "npm run build && vite --mode e2e",
     "fmt": "biome format --write src e2e ",
     "prepublishOnly": "npm run build"
   },
@@ -55,7 +53,6 @@
     "@biomejs/biome": "1.8.3",
     "@playwright/test": "^1.46.1",
     "@types/node": "^22.5.2",
-    "coi-serviceworker": "^0.1.7",
     "playwright": "^1.46.1",
     "typescript": "^5.5.3",
     "vite": "^5.4.2"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,10 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       port: isE2E ? 3001 : 3000,
+      headers: {
+        'Cross-Origin-Opener-Policy': 'same-origin',
+        'Cross-Origin-Embedder-Policy': 'require-corp'
+      }
     },
     resolve: {
       alias: {


### PR DESCRIPTION
This issue does not complete the following, but it will certainly allow Safari to run without problems on a local server started with the `dev:e2e` command.
https://github.com/shinshin86/neverchange/issues/6

## TODO

- [x] If we look into Netlify or other environments and find the same problem as with GitHub Pages, we need to update the README so as not to confuse developers.